### PR TITLE
feat: prepare for v0.0.1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest
 
       - name: Build and push container image
         uses: docker/build-push-action@v6
@@ -54,3 +55,39 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  release:
+    name: Create GitHub Release
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Generate install manifest
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          cd config/manager && kustomize edit set image controller=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
+          cd ../..
+          mkdir -p dist
+          kustomize build config/default > dist/install.yaml
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/install.yaml

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,8 +6,20 @@ on:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: E2E (K8s ${{ matrix.k8s-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test against multiple Kubernetes versions
+        # See https://github.com/kubernetes-sigs/kind/releases for available images
+        k8s-version:
+          - v1.32.0
+          - v1.31.4
+          - v1.30.8
+          - v1.29.12
+          - v1.28.15
+
     steps:
       - name: Clone the code
         uses: actions/checkout@v4
@@ -26,7 +38,24 @@ jobs:
       - name: Verify kind installation
         run: kind version
 
-      - name: Running Test e2e
+      - name: Running Test e2e on Kubernetes ${{ matrix.k8s-version }}
         run: |
           go mod tidy
-          make test-e2e
+          make test-e2e KIND_K8S_VERSION=${{ matrix.k8s-version }}
+
+  # Summary job that reports overall success/failure
+  test-e2e-summary:
+    name: E2E Test Summary
+    needs: test-e2e
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.test-e2e.result }}" == "success" ]; then
+            echo "All E2E tests passed!"
+            exit 0
+          else
+            echo "Some E2E tests failed!"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ Two reconcilers watch Kubernetes resources and act on annotation changes:
 - **ConfigMapWatcherReconciler** (`configmapwatcher_controller.go`): Watches ConfigMaps
 
 Both support these annotations:
-- `replizieren.dev/replicate`: `"true"` (all namespaces) or comma-separated list (e.g., `"ns1,ns2"`)
+- `replizieren.dev/replicate`: comma-separated namespace list (e.g., `"ns1,ns2"`) or `"true"` (legacy all namespaces)
+- `replizieren.dev/replicate-all`: `"true"` to replicate to all namespaces (preferred over `replicate: "true"`)
 - `replizieren.dev/rollout-on-update`: `"true"` to restart deployments using the resource
 
 ### Key Flow

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= replizieren-test-e2e
+# KIND_K8S_VERSION can be set to test specific Kubernetes versions (e.g., v1.30.0, v1.29.4)
+# See https://github.com/kubernetes-sigs/kind/releases for available versions
+KIND_K8S_VERSION ?=
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
@@ -73,7 +76,11 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
 	}
-	$(KIND) create cluster --name $(KIND_CLUSTER)
+	@if [ -n "$(KIND_K8S_VERSION)" ]; then \
+		$(KIND) create cluster --name $(KIND_CLUSTER) --image kindest/node:$(KIND_K8S_VERSION); \
+	else \
+		$(KIND) create cluster --name $(KIND_CLUSTER); \
+	fi
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/README.md
+++ b/README.md
@@ -23,15 +23,11 @@
 ### Installation
 
 ```bash
-# Using the pre-built image from GitHub Container Registry
+# Install a specific version (recommended)
+kubectl apply -f https://github.com/Kammerdiener-Technologies/replizieren/releases/download/v0.0.1/install.yaml
+
+# Or install the latest development version
 kubectl apply -f https://raw.githubusercontent.com/Kammerdiener-Technologies/replizieren/main/dist/install.yaml
-```
-
-Or deploy with a specific version:
-
-```bash
-# Deploy using kustomize
-make deploy IMG=ghcr.io/kammerdiener-technologies/replizieren:v1.0.0
 ```
 
 ### Basic Usage
@@ -59,9 +55,12 @@ The Secret will be automatically replicated to `target-namespace`.
 |------------|--------|-------------|
 | `replizieren.dev/replicate` | `"namespace"` | Replicate to a single namespace |
 | `replizieren.dev/replicate` | `"ns1,ns2,ns3"` | Replicate to multiple namespaces |
-| `replizieren.dev/replicate` | `"true"` | Replicate to all namespaces |
+| `replizieren.dev/replicate-all` | `"true"` | Replicate to all namespaces (recommended) |
+| `replizieren.dev/replicate` | `"true"` | Replicate to all namespaces (legacy) |
 | `replizieren.dev/replicate` | `"false"` or empty | Disable replication |
 | `replizieren.dev/rollout-on-update` | `"true"` | Restart Deployments using this resource when it changes |
+
+> **Note:** Use `replizieren.dev/replicate-all: "true"` for replicating to all namespaces. This is preferred over `replizieren.dev/replicate: "true"` because it allows you to have a namespace literally named "true". Set `replicate-all: "false"` explicitly if you need to target a namespace named "true".
 
 ## Examples
 
@@ -89,7 +88,7 @@ metadata:
   name: registry-credentials
   namespace: default
   annotations:
-    replizieren.dev/replicate: "true"
+    replizieren.dev/replicate-all: "true"
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: ...
@@ -128,9 +127,13 @@ The operator detects Deployments using a Secret or ConfigMap by checking:
 
 ## Installation Options
 
-### From GitHub Container Registry (Recommended)
+### From GitHub Releases (Recommended)
 
 ```bash
+# Install a specific version
+kubectl apply -f https://github.com/Kammerdiener-Technologies/replizieren/releases/download/v0.0.1/install.yaml
+
+# Or latest development version
 kubectl apply -f https://raw.githubusercontent.com/Kammerdiener-Technologies/replizieren/main/dist/install.yaml
 ```
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,6 @@
 resources:
 - manager.yaml
+images:
+- name: controller
+  newName: ghcr.io/kammerdiener-technologies/replizieren
+  newTag: latest

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1,0 +1,268 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+    control-plane: controller-manager
+  name: replizieren-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+  name: replizieren-controller-manager
+  namespace: replizieren-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+  name: replizieren-leader-election-role
+  namespace: replizieren-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: replizieren-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/finalizers
+  - secrets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  - secrets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: replizieren-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: replizieren-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+  name: replizieren-leader-election-rolebinding
+  namespace: replizieren-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: replizieren-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: replizieren-controller-manager
+  namespace: replizieren-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+  name: replizieren-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: replizieren-manager-role
+subjects:
+- kind: ServiceAccount
+  name: replizieren-controller-manager
+  namespace: replizieren-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: replizieren-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: replizieren-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: replizieren-controller-manager
+  namespace: replizieren-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+    control-plane: controller-manager
+  name: replizieren-controller-manager-metrics-service
+  namespace: replizieren-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: replizieren
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: replizieren
+    control-plane: controller-manager
+  name: replizieren-controller-manager
+  namespace: replizieren-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: replizieren
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: replizieren
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: ghcr.io/kammerdiener-technologies/replizieren:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports: []
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts: []
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: replizieren-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes: []

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,7 +20,7 @@ metadata:
   name: docker-registry-credentials
   namespace: default
   annotations:
-    replizieren.dev/replicate: "true"
+    replizieren.dev/replicate-all: "true"
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: |
@@ -237,7 +237,7 @@ metadata:
   name: logging-config
   namespace: shared-config
   annotations:
-    replizieren.dev/replicate: "true"  # All namespaces
+    replizieren.dev/replicate-all: "true"
 data:
   log_level: "info"
   log_format: "json"
@@ -386,12 +386,12 @@ Store your annotated resources in Git and deploy with ArgoCD or Flux:
 ```
 manifests/
 ├── secrets/
-│   ├── docker-registry.yaml    # replicate: "true"
+│   ├── docker-registry.yaml    # replicate-all: "true"
 │   ├── tls-certs.yaml          # replicate: "ingress-nginx"
 │   └── database-creds.yaml     # replicate: "api, worker"
 └── configmaps/
     ├── feature-flags.yaml      # replicate: "staging, prod"
-    └── logging-config.yaml     # replicate: "true"
+    └── logging-config.yaml     # replicate-all: "true"
 ```
 
 ### 3. Monitor Replication

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,14 +29,14 @@ kind: Secret
 metadata:
   name: registry-credentials
   annotations:
-    replizieren.dev/replicate: "true"  # Replicate to ALL namespaces
+    replizieren.dev/replicate-all: "true"  # Replicate to ALL namespaces
 ```
 
 ### Flexible Targeting
 
 - **Single namespace**: `replizieren.dev/replicate: "production"`
 - **Multiple namespaces**: `replizieren.dev/replicate: "staging, production, testing"`
-- **All namespaces**: `replizieren.dev/replicate: "true"`
+- **All namespaces**: `replizieren.dev/replicate-all: "true"`
 
 ### Automatic Rollout Triggers
 
@@ -57,6 +57,10 @@ metadata:
 ### 1. Install Replizieren
 
 ```bash
+# Install a specific version (recommended)
+kubectl apply -f https://github.com/Kammerdiener-Technologies/replizieren/releases/download/v0.0.1/install.yaml
+
+# Or install the latest development version
 kubectl apply -f https://raw.githubusercontent.com/Kammerdiener-Technologies/replizieren/main/dist/install.yaml
 ```
 
@@ -96,7 +100,7 @@ metadata:
   name: docker-registry
   namespace: default
   annotations:
-    replizieren.dev/replicate: "true"
+    replizieren.dev/replicate-all: "true"
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: ...
@@ -137,6 +141,20 @@ data:
   flags.json: |
     {"new_feature": true}
 ```
+
+## Compatibility
+
+Replizieren is tested against multiple Kubernetes versions:
+
+| Kubernetes | Status |
+|------------|--------|
+| 1.32.x | Tested |
+| 1.31.x | Tested |
+| 1.30.x | Tested |
+| 1.29.x | Tested |
+| 1.28.x | Tested |
+
+See [API Reference](api-reference#compatibility) for full compatibility details.
 
 ## Next Steps
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,11 +13,19 @@ This guide covers different ways to install Replizieren in your Kubernetes clust
 - `kubectl` configured to communicate with your cluster
 - Cluster-admin privileges (for RBAC setup)
 
-## Quick Install
+## Quick Install (Recommended)
 
-The fastest way to get started is using the pre-built manifests:
+The easiest way to install is using the install manifest from a specific release:
 
 ```bash
+# Install a specific version (recommended for production)
+kubectl apply -f https://github.com/Kammerdiener-Technologies/replizieren/releases/download/v0.0.1/install.yaml
+```
+
+Or install the latest development version from main:
+
+```bash
+# Install latest (for development/testing)
 kubectl apply -f https://raw.githubusercontent.com/Kammerdiener-Technologies/replizieren/main/dist/install.yaml
 ```
 
@@ -37,21 +45,21 @@ kubectl get pods -n replizieren-system
 # replizieren-controller-manager-xxx        1/1     Running   0          30s
 ```
 
-## Install from GitHub Container Registry
+## Install with Kustomize
 
-For production deployments, use a specific version:
+For more control over the installation, use kustomize:
 
 ```bash
-# Using kustomize
-kubectl apply -k https://github.com/Kammerdiener-Technologies/replizieren/config/default?ref=v1.0.0
+# Using kustomize with a specific version
+kubectl apply -k https://github.com/Kammerdiener-Technologies/replizieren/config/default?ref=v0.0.1
 ```
 
-Or with `make`:
+Or clone and deploy:
 
 ```bash
 git clone https://github.com/Kammerdiener-Technologies/replizieren.git
 cd replizieren
-make deploy IMG=ghcr.io/kammerdiener-technologies/replizieren:v1.0.0
+make deploy IMG=ghcr.io/kammerdiener-technologies/replizieren:v0.0.1
 ```
 
 ## Build from Source
@@ -150,8 +158,8 @@ make undeploy
 ### Manual Uninstall
 
 ```bash
-# Delete the deployment
-kubectl delete -f https://raw.githubusercontent.com/Kammerdiener-Technologies/replizieren/main/dist/install.yaml
+# Delete using the same manifest you installed with
+kubectl delete -f https://github.com/Kammerdiener-Technologies/replizieren/releases/download/v0.0.1/install.yaml
 
 # Or delete namespace (removes everything)
 kubectl delete namespace replizieren-system

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,9 +21,21 @@ Controls where the resource should be replicated.
 |-------|----------|
 | `"namespace"` | Replicate to a single namespace |
 | `"ns1, ns2, ns3"` | Replicate to multiple namespaces (comma-separated) |
-| `"true"` | Replicate to ALL namespaces in the cluster |
+| `"true"` | Replicate to ALL namespaces (legacy, use `replicate-all` instead) |
 | `"false"` | Explicitly disable replication |
 | (empty/missing) | No replication |
+
+### replizieren.dev/replicate-all
+
+Controls replication to all namespaces. This is the preferred way to replicate to all namespaces.
+
+| Value | Behavior |
+|-------|----------|
+| `"true"` | Replicate to ALL namespaces in the cluster |
+| `"false"` | Disable "all namespaces" mode (allows `replicate: "true"` to target a namespace named "true") |
+| (empty/missing) | Use `replicate` annotation behavior |
+
+> **Recommendation:** Use `replicate-all: "true"` instead of `replicate: "true"` for replicating to all namespaces. This removes ambiguity if you have a namespace literally named "true".
 
 ### replizieren.dev/rollout-on-update
 
@@ -84,7 +96,7 @@ metadata:
   name: docker-registry
   namespace: default
   annotations:
-    replizieren.dev/replicate: "true"
+    replizieren.dev/replicate-all: "true"
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: eyJhdXRocyI6e319
@@ -216,7 +228,7 @@ kubectl annotate secret my-secret \
 
 ### 1. Use Specific Namespaces When Possible
 
-Instead of `"true"` (all namespaces), specify exactly which namespaces need the resource:
+Instead of `replicate-all: "true"` (all namespaces), specify exactly which namespaces need the resource:
 
 ```yaml
 annotations:


### PR DESCRIPTION
## Summary

This PR prepares the project for the v0.0.1 release with several improvements:

- **Fix install script 404**: Generated `dist/install.yaml` and updated publish workflow to attach it to GitHub releases
- **Add `replicate-all` annotation**: New `replizieren.dev/replicate-all: "true"` annotation for unambiguous all-namespace replication (allows targeting a namespace literally named "true")
- **Multi-version K8s testing**: CI now tests against Kubernetes v1.28, v1.29, v1.30, v1.31, and v1.32
- **Compatibility documentation**: Added Kubernetes compatibility chart to docs

## Changes

### New Features
- `replizieren.dev/replicate-all: "true"` - Preferred way to replicate to all namespaces
- Legacy `replizieren.dev/replicate: "true"` still works for backward compatibility
- Set `replicate-all: "false"` to target a namespace literally named "true"

### CI/CD
- Publish workflow now creates GitHub releases with `install.yaml` attached
- E2E tests run against 5 Kubernetes versions (v1.28-v1.32)
- Added `KIND_K8S_VERSION` parameter to Makefile for local testing

### Documentation
- Updated all docs to use new `replicate-all` annotation
- Added Kubernetes compatibility chart
- Updated install instructions to use release assets

## Test plan

- [x] Unit tests pass for new `replicate-all` annotation logic
- [x] All existing tests continue to pass
- [ ] CI runs E2E tests against multiple K8s versions
- [ ] After merge, tag `v0.0.1` to trigger release workflow

## Release Steps

After merging:
```bash
git checkout main
git pull origin main
git tag -a v0.0.1 -m "Release v0.0.1 - Initial release"
git push origin v0.0.1
```