### PR TITLE
feat: add namespace watcher and Helm chart for v0.1.0

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,0 +1,56 @@
+name: Release Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,47 @@
+name: Release Helm Chart
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  CHART_PATH: charts/replizieren
+
+jobs:
+  release-helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get chart version
+        id: chart
+        run: |
+          VERSION=$(grep '^version:' ${{ env.CHART_PATH }}/Chart.yaml | awk '{print $2}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Package Helm chart
+        run: |
+          helm package ${{ env.CHART_PATH }}
+
+      - name: Push Helm chart to OCI registry
+        run: |
+          helm push replizieren-${{ steps.chart.outputs.version }}.tgz oci://${{ env.REGISTRY }}/kammerdiener-technologies/charts

--- a/charts/replizieren/Chart.yaml
+++ b/charts/replizieren/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: replizieren
+description: A Kubernetes operator that replicates Secrets and ConfigMaps across namespaces and triggers deployment rollouts on resource changes
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - kubernetes
+  - operator
+  - secrets
+  - configmaps
+  - replication
+  - namespace
+home: https://github.com/Kammerdiener-Technologies/replizieren
+sources:
+  - https://github.com/Kammerdiener-Technologies/replizieren
+maintainers:
+  - name: Kammerdiener Technologies
+    url: https://github.com/Kammerdiener-Technologies

--- a/charts/replizieren/templates/NOTES.txt
+++ b/charts/replizieren/templates/NOTES.txt
@@ -1,0 +1,26 @@
+Replizieren has been installed!
+
+To replicate a Secret to all namespaces, add this annotation:
+  replizieren.dev/replicate-all: "true"
+
+To replicate a Secret to specific namespaces, add this annotation:
+  replizieren.dev/replicate: "namespace1,namespace2"
+
+To trigger deployment rollouts when a resource changes:
+  replizieren.dev/rollout-on-update: "true"
+
+Example Secret:
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: my-shared-secret
+    namespace: default
+    annotations:
+      replizieren.dev/replicate-all: "true"
+      replizieren.dev/rollout-on-update: "true"
+  type: Opaque
+  stringData:
+    api-key: "my-secret-value"
+
+For more information, visit:
+  https://github.com/Kammerdiener-Technologies/replizieren

--- a/charts/replizieren/templates/_helpers.tpl
+++ b/charts/replizieren/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "replizieren.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "replizieren.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "replizieren.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "replizieren.labels" -}}
+helm.sh/chart: {{ include "replizieren.chart" . }}
+{{ include "replizieren.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "replizieren.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "replizieren.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "replizieren.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "replizieren.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/replizieren/templates/clusterrole.yaml
+++ b/charts/replizieren/templates/clusterrole.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "replizieren.fullname" . }}-manager-role
+  labels:
+    {{- include "replizieren.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/finalizers
+  - secrets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  - secrets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch

--- a/charts/replizieren/templates/clusterrolebinding.yaml
+++ b/charts/replizieren/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "replizieren.fullname" . }}-manager-rolebinding
+  labels:
+    {{- include "replizieren.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "replizieren.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "replizieren.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/replizieren/templates/deployment.yaml
+++ b/charts/replizieren/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "replizieren.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+    {{- include "replizieren.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      {{- include "replizieren.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        control-plane: controller-manager
+        {{- include "replizieren.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "replizieren.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: manager
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /manager
+        args:
+        {{- if .Values.controller.leaderElect }}
+        - --leader-elect
+        {{- end }}
+        - --health-probe-bind-address={{ .Values.controller.healthProbeBindAddress }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/replizieren/templates/serviceaccount.yaml
+++ b/charts/replizieren/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "replizieren.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "replizieren.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/replizieren/values.yaml
+++ b/charts/replizieren/values.yaml
@@ -1,0 +1,62 @@
+# Default values for replizieren.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/kammerdiener-technologies/replizieren
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Controller configuration
+controller:
+  # Enable leader election for controller manager
+  leaderElect: true
+  # Health probe bind address
+  healthProbeBindAddress: ":8081"
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - "ALL"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod labels
+podLabels: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -214,6 +214,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ConfigMapWatcher")
 		os.Exit(1)
 	}
+	if err := (&controller.NamespaceReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if metricsCertWatcher != nil {

--- a/internal/controller/namespace_controller.go
+++ b/internal/controller/namespace_controller.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// NamespaceReconciler reconciles a Namespace object to trigger replication
+// of secrets and configmaps that have replicate-all enabled
+type NamespaceReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+
+// Reconcile handles namespace creation events and replicates secrets/configmaps
+// that have replicate-all annotation to the new namespace.
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var namespace corev1.Namespace
+	if err := r.Get(ctx, req.NamespacedName, &namespace); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Skip if namespace is being deleted
+	if namespace.DeletionTimestamp != nil {
+		logger.Info("Namespace is being deleted, skipping", "namespace", namespace.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Skip system namespaces
+	if IsSystemNamespace(namespace.Name) {
+		logger.Info("Skipping system namespace", "namespace", namespace.Name)
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("New namespace detected, checking for resources to replicate", "namespace", namespace.Name)
+
+	// Replicate secrets with replicate-all annotation
+	secrets, err := GetSecretsToReplicateAll(ctx, r.Client)
+	if err != nil {
+		logger.Error(err, "Failed to list secrets for replication")
+		return ctrl.Result{}, err
+	}
+
+	for _, secret := range secrets {
+		if secret.Namespace == namespace.Name {
+			continue // Don't replicate to source namespace
+		}
+		if err := r.replicateSecret(ctx, &secret, namespace.Name); err != nil {
+			logger.Error(err, "Failed to replicate secret", "secret", secret.Name, "from", secret.Namespace, "to", namespace.Name)
+			continue
+		}
+		logger.Info("Replicated secret to new namespace", "secret", secret.Name, "from", secret.Namespace, "to", namespace.Name)
+	}
+
+	// Replicate configmaps with replicate-all annotation
+	configmaps, err := GetConfigMapsToReplicateAll(ctx, r.Client)
+	if err != nil {
+		logger.Error(err, "Failed to list configmaps for replication")
+		return ctrl.Result{}, err
+	}
+
+	for _, cm := range configmaps {
+		if cm.Namespace == namespace.Name {
+			continue // Don't replicate to source namespace
+		}
+		if err := r.replicateConfigMap(ctx, &cm, namespace.Name); err != nil {
+			logger.Error(err, "Failed to replicate configmap", "configmap", cm.Name, "from", cm.Namespace, "to", namespace.Name)
+			continue
+		}
+		logger.Info("Replicated configmap to new namespace", "configmap", cm.Name, "from", cm.Namespace, "to", namespace.Name)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NamespaceReconciler) replicateSecret(ctx context.Context, original *corev1.Secret, namespace string) error {
+	clone := original.DeepCopy()
+	clone.Namespace = namespace
+	clone.ResourceVersion = ""
+	clone.UID = ""
+
+	existing := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: clone.Name, Namespace: namespace}, existing)
+	if err != nil && errors.IsNotFound(err) {
+		return r.Create(ctx, clone)
+	} else if err != nil {
+		return err
+	}
+
+	clone.ResourceVersion = existing.ResourceVersion
+	return r.Update(ctx, clone)
+}
+
+func (r *NamespaceReconciler) replicateConfigMap(ctx context.Context, original *corev1.ConfigMap, namespace string) error {
+	clone := original.DeepCopy()
+	clone.Namespace = namespace
+	clone.ResourceVersion = ""
+	clone.UID = ""
+
+	existing := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{Name: clone.Name, Namespace: namespace}, existing)
+	if err != nil && errors.IsNotFound(err) {
+		return r.Create(ctx, clone)
+	} else if err != nil {
+		return err
+	}
+
+	clone.ResourceVersion = existing.ResourceVersion
+	return r.Update(ctx, clone)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Named("namespace").
+		Complete(r)
+}

--- a/internal/controller/namespace_controller_test.go
+++ b/internal/controller/namespace_controller_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Namespace Controller", func() {
+	const (
+		timeout  = 30 * time.Second
+		interval = 1 * time.Second
+	)
+
+	// Test 1: New namespace should trigger replication of replicate-all secrets
+	It("should replicate secrets with replicate-all to new namespace", func() {
+		srcNs := createTestNamespace("ns-src-secret")
+
+		// Create a secret with replicate-all annotation
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ns-watch-secret",
+				Namespace: srcNs.Name,
+				Annotations: map[string]string{
+					ReplicateAllKey: "true",
+				},
+			},
+			StringData: map[string]string{"key": "value"},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		// Create a new namespace - the secret should be replicated to it
+		targetNs := createTestNamespace("ns-tgt-secret")
+
+		// Verify the secret was replicated
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: targetNs.Name}, &corev1.Secret{})
+		}, timeout, interval).Should(Succeed())
+	})
+
+	// Test 2: New namespace should trigger replication of replicate-all configmaps
+	It("should replicate configmaps with replicate-all to new namespace", func() {
+		srcNs := createTestNamespace("ns-src-cm")
+
+		// Create a configmap with replicate-all annotation
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ns-watch-configmap",
+				Namespace: srcNs.Name,
+				Annotations: map[string]string{
+					ReplicateAllKey: "true",
+				},
+			},
+			Data: map[string]string{"config": "data"},
+		}
+		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+		// Create a new namespace - the configmap should be replicated to it
+		targetNs := createTestNamespace("ns-tgt-cm")
+
+		// Verify the configmap was replicated
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: cm.Name, Namespace: targetNs.Name}, &corev1.ConfigMap{})
+		}, timeout, interval).Should(Succeed())
+	})
+
+	// Test 3: Secrets with specific namespace targets should not replicate to unrelated namespaces
+	It("should not replicate secrets with specific targets to unrelated namespaces", func() {
+		srcNs := createTestNamespace("ns-src-specific")
+		specificTarget := createTestNamespace("ns-specific-target")
+
+		// Create a secret with specific namespace target
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "specific-target-secret",
+				Namespace: srcNs.Name,
+				Annotations: map[string]string{
+					ReplicateKey: specificTarget.Name,
+				},
+			},
+			StringData: map[string]string{"key": "value"},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		// Wait for replication to specific target
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: specificTarget.Name}, &corev1.Secret{})
+		}, timeout, interval).Should(Succeed())
+
+		// Create an unrelated namespace
+		unrelatedNs := createTestNamespace("ns-unrelated")
+
+		// Secret should NOT be replicated to the unrelated namespace
+		Consistently(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: unrelatedNs.Name}, &corev1.Secret{})
+		}, 5*time.Second, interval).ShouldNot(Succeed())
+	})
+
+	// Test 4: Replicated data should match source
+	It("should replicate secret data that matches source to new namespace", func() {
+		srcNs := createTestNamespace("ns-src-data")
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "data-match-ns-secret",
+				Namespace: srcNs.Name,
+				Annotations: map[string]string{
+					ReplicateAllKey: "true",
+				},
+			},
+			StringData: map[string]string{
+				"username": "admin",
+				"password": "secret123",
+			},
+			Type: corev1.SecretTypeOpaque,
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		targetNs := createTestNamespace("ns-tgt-data")
+
+		Eventually(func() map[string][]byte {
+			var replicated corev1.Secret
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: targetNs.Name}, &replicated); err != nil {
+				return nil
+			}
+			return replicated.Data
+		}, timeout, interval).Should(And(
+			HaveKeyWithValue("username", []byte("admin")),
+			HaveKeyWithValue("password", []byte("secret123")),
+		))
+	})
+
+	// Test 5: Legacy replicate: true should also work
+	It("should replicate secrets with legacy replicate: true to new namespace", func() {
+		srcNs := createTestNamespace("ns-src-legacy")
+
+		// Create a secret with legacy replicate: true annotation
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "legacy-replicate-secret",
+				Namespace: srcNs.Name,
+				Annotations: map[string]string{
+					ReplicateKey: "true",
+				},
+			},
+			StringData: map[string]string{"key": "legacy"},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		// Create a new namespace - the secret should be replicated to it
+		targetNs := createTestNamespace("ns-tgt-legacy")
+
+		// Verify the secret was replicated
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: targetNs.Name}, &corev1.Secret{})
+		}, timeout, interval).Should(Succeed())
+	})
+})
+
+func createTestNamespace(name string) *corev1.Namespace {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	return ns
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -106,6 +106,12 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&NamespaceReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err := mgr.Start(ctx)


### PR DESCRIPTION
## Summary

- Add **Namespace Watcher Controller** that automatically replicates secrets/configmaps to newly created namespaces
- Add **Helm chart** for easy deployment (`charts/replizieren/`)
- Add **GitHub Actions workflows** for Docker and Helm OCI publishing

## Changes

### Namespace Watcher
- New `NamespaceReconciler` watches for namespace creation events
- Automatically replicates resources with `replizieren.dev/replicate-all: "true"` to new namespaces
- Skips system namespaces (kube-system, kube-public, kube-node-lease)
- Includes unit tests

### Helm Chart
- Located at `charts/replizieren/`
- Includes deployment, RBAC, service account templates
- Configurable via `values.yaml`

### CI/CD
- `helm-release.yaml` - Publishes Helm chart to `oci://ghcr.io/kammerdiener-technologies/charts`
- `docker-release.yaml` - Builds and publishes multi-arch Docker image

## Test plan
- [x] `make test` - all tests pass
- [x] `make lint` - no issues
- [x] `helm lint charts/replizieren` - passes
- [x] `helm template` generates valid manifests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds namespace-aware replication and packaging/release infrastructure.
> 
> - New `NamespaceReconciler` wires into `cmd/main.go` to replicate `Secrets`/`ConfigMaps` with `replizieren.dev/replicate-all: "true"` into newly created namespaces; skips system namespaces; includes unit tests
> - Extends replication helpers (`replicator.go`) with system-namespace checks and list helpers for replicate-all resources
> - New Helm chart in `charts/replizieren/` (Deployment, RBAC, ServiceAccount, values, NOTES) targeting image `ghcr.io/kammerdiener-technologies/replizieren` v0.1.0
> - New GitHub Actions: `docker-release.yaml` (multi-arch build/push) and `helm-release.yaml` (package/push chart to OCI)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1600a78c4051082eb1f0c034e63c9f9106734b61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->